### PR TITLE
Feature: Scoreboards and turns

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -51,7 +51,7 @@
   /* Shadow */
   --box-shadow-sm: #f0f6fc1a 0px 4px 6px -1px, #f0f6fc0f 0px 2px 4px -1px;
 
-  /* Breakpoints */
+  /* Breakpoints (won't work on media queries but left for reference) */
   --bp-xl: 1200px;
   --bp-lg: 1024px;
   --bp-md: 768px;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -191,4 +191,56 @@
   aspect-ratio: 1/1;
   max-width: 100%;
   max-height: 100%;
+  cursor: pointer;
+}
+
+.main-content__score-area {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: baseline;
+}
+.score-area__player {
+  padding: var(--spacing--lg);
+  border-radius: var(--border-radius);
+  margin: var(--spacing--sm);
+}
+
+.player-1 {
+  border: var(--border-width) solid var(--player-1-accent-color);
+}
+
+.player-2 {
+  border: var(--border-width) solid var(--player-2-accent-color);
+}
+
+.score-area__player.player-1.status--active {
+  background-color: var(--player-1-accent-color);
+}
+
+.score-area__player.player-2.status--active {
+  background-color: var(--player-2-accent-color);
+}
+
+/* Scores hidden by default, shown on game start */
+.main-content__score-area {
+  display: none;
+}
+
+/* Scores hidden by default, shown on game start */
+.main-content__score-area.game-started {
+  display: flex;
+  margin: var(--spacing--lg);
+}
+
+/* Start game button shown by default, hidden on game start */
+.game-area__button.game-started {
+  display: none;
+}
+
+/* Desktop */
+@media (min-width: 768px) {
+  .main-content__score-area {
+    flex-direction: row;
+  }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,6 +8,8 @@
   --green: #2ea44f;
   --pure-black: #000;
   --pure-white: #fff;
+  --red: #ff5f56;
+  --blue: #0070f3;
 
   /* Borders */
   --border-color: var(--dark-gray);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -117,6 +117,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing--md);
 }
 
 .main-content__game-area {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,8 @@
   --background-color: var(--light-gray);
   --header-background-color: var(--dark-gray);
   --button-background-color--primary: var(--green);
+  --player-1-accent-color: var(--blue);
+  --player-2-accent-color: var(--red);
 
   /* Font */
   --font-color: var(--white);

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,31 @@ const KNOWN_CSS_CLASSES = {
   tile: "row__tile",
   whiteChecker: "checker--white",
   redChecker: "checker--red",
+  startGameButton: "game-area__button",
+  scoreboard: "main-content__score-area",
+  playersScoreboards: {
+    both: "score-area__player",
+    status: "player__status",
+    p1: "score-area__player player1",
+    p2: "score-area__player player2",
+  },
+  gameStatus: {
+    gameStarted: "game-started",
+    playerTurnActive: "status--active",
+  },
+};
+
+const KNOWN_EVENT_NAMES = {
+  onClick: "click",
+};
+
+const FIXTURE_TEXT = {
+  game: {
+    turns: {
+      activeTurn: "Active turn",
+      waiting: "Waiting",
+    },
+  },
 };
 
 const KNOWN_HTML_TEMPLATE_IDS = {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -79,6 +79,7 @@ const appState = {
     },
   },
 };
+
 const renderNewTurn = () => {
   const isP1CurrentTurnOwner =
     appState.game.turns.currentTurn === GAME_CONFIG.players.p1.id;
@@ -137,39 +138,58 @@ const getContentFromHTMLTemplate = ({ templateId, elementCssClass }) => {
     .querySelector(`.${elementCssClass}`);
 };
 
+const generateTileId = (rowIndex, cellIndex) =>
+  `row-${rowIndex}-tile-${cellIndex}`;
+
+const onClickTileHandler = (tile) => {
+  const hasOwnChecker =
+    appState.game.turns.currentTurn != null &&
+    !!tile.querySelector(
+      `.${GAME_CONFIG.players[appState.game.turns.currentTurn].checkerClass}`
+    );
+
+  if (hasOwnChecker) {
+    renderNewTurn();
+  }
+};
+
 const renderRows = (boardElement, initialBoardMatrix) => {
   const rowElementParams = {
     templateId: KNOWN_HTML_TEMPLATE_IDS.board.row,
     elementCssClass: KNOWN_CSS_CLASSES.row,
   };
 
-  const rowElement = getContentFromTemplate(rowElementParams);
+  const rowElement = getContentFromHTMLTemplate(rowElementParams);
 
   const tileElementParams = {
     templateId: KNOWN_HTML_TEMPLATE_IDS.board.tile,
     elementCssClass: KNOWN_CSS_CLASSES.tile,
   };
 
-  const tileElement = getContentFromTemplate(tileElementParams);
+  const tileElement = getContentFromHTMLTemplate(tileElementParams);
 
   const whiteCheckerParams = {
     templateId: KNOWN_HTML_TEMPLATE_IDS.board.checkers.white,
     elementCssClass: KNOWN_CSS_CLASSES.whiteChecker,
   };
 
-  const whiteCheckerElement = getContentFromTemplate(whiteCheckerParams);
+  const whiteCheckerElement = getContentFromHTMLTemplate(whiteCheckerParams);
 
   const redCheckerParams = {
     templateId: KNOWN_HTML_TEMPLATE_IDS.board.checkers.red,
     elementCssClass: KNOWN_CSS_CLASSES.redChecker,
   };
 
-  const redCheckerElement = getContentFromTemplate(redCheckerParams);
+  const redCheckerElement = getContentFromHTMLTemplate(redCheckerParams);
 
-  initialBoardMatrix.forEach((row) => {
+  initialBoardMatrix.forEach((row, rowIndex) => {
     const clonedRow = rowElement.cloneNode(true);
-    row.forEach((cell) => {
+    row.forEach((cell, cellIndex) => {
       const clonedTile = tileElement.cloneNode(true);
+      clonedTile.id = generateTileId(rowIndex, cellIndex);
+      clonedTile.addEventListener(KNOWN_EVENT_NAMES.onClick, () => {
+        onClickTileHandler(clonedTile);
+      });
       switch (cell) {
         case 1:
           const clonedWhiteChecker = whiteCheckerElement.cloneNode(true);
@@ -181,7 +201,6 @@ const renderRows = (boardElement, initialBoardMatrix) => {
           clonedTile.appendChild(clonedRedChecker);
           clonedRow.appendChild(clonedTile);
           break;
-
         default:
           clonedRow.appendChild(clonedTile);
           break;
@@ -235,6 +254,18 @@ const getInitialBoardMatrix = ({ dimension, checkersRows, players }) => {
     );
 };
 
+const hideButtonShowScores = () => {
+  const [gameScoreboard] = document.getElementsByClassName(
+    KNOWN_CSS_CLASSES.scoreboard
+  );
+  gameScoreboard.classList.add(KNOWN_CSS_CLASSES.gameStatus.gameStarted);
+  startGameButton.classList.add(KNOWN_CSS_CLASSES.gameStatus.gameStarted);
+};
+
+const [startGameButton] = document.getElementsByClassName(
+  KNOWN_CSS_CLASSES.startGameButton
+);
+
 const bootstrapApp = ({ players, board: { dimension, checkersRows } }) => {
   const [boardElement] = document.getElementsByClassName(
     KNOWN_CSS_CLASSES.board
@@ -247,7 +278,17 @@ const bootstrapApp = ({ players, board: { dimension, checkersRows } }) => {
   };
 
   const initialBoardMatrix = getInitialBoardMatrix(matrixGenerationParams);
+
+  appState.game.checkersStatus.value = initialBoardMatrix;
+
   renderRows(boardElement, initialBoardMatrix);
+
+  startGameButton.addEventListener(KNOWN_EVENT_NAMES.onClick, startGame);
+};
+
+const startGame = () => {
+  hideButtonShowScores();
+  appState.game.turns.currentTurn = GAME_CONFIG.players.p1.id;
 };
 
 window.onload = bootstrapApp(GAME_CONFIG);

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -129,6 +129,8 @@ const renderNewTurn = () => {
     ? GAME_CONFIG.players.p2.id
     : GAME_CONFIG.players.p1.id;
 };
+
+const getContentFromHTMLTemplate = ({ templateId, elementCssClass }) => {
   const template = document.getElementById(templateId).content.cloneNode(true);
   return document
     .importNode(template, true)

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -61,7 +61,24 @@ const GAME_CONFIG = {
   },
 };
 
-const getContentFromTemplate = ({ templateId, elementCssClass }) => {
+const appState = {
+  game: {
+    checkersStatus: {
+      value: null,
+    },
+    turns: {
+      currentTurn: null,
+    },
+    players: {
+      p1: {
+        checkersLeft: 12,
+      },
+      p2: {
+        checkersLeft: 12,
+      },
+    },
+  },
+};
   const template = document.getElementById(templateId).content.cloneNode(true);
   return document
     .importNode(template, true)

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -79,6 +79,56 @@ const appState = {
     },
   },
 };
+const renderNewTurn = () => {
+  const isP1CurrentTurnOwner =
+    appState.game.turns.currentTurn === GAME_CONFIG.players.p1.id;
+
+  const [scoreboard] = document.getElementsByClassName(
+    KNOWN_CSS_CLASSES.scoreboard
+  );
+
+  const [player1Scoreboard, player2Scoreboard] =
+    scoreboard.getElementsByClassName(
+      KNOWN_CSS_CLASSES.playersScoreboards.both
+    );
+
+  const [p1Status] = player1Scoreboard.getElementsByClassName(
+    KNOWN_CSS_CLASSES.playersScoreboards.status
+  );
+
+  const [p2Status] = player2Scoreboard.getElementsByClassName(
+    KNOWN_CSS_CLASSES.playersScoreboards.status
+  );
+
+  if (isP1CurrentTurnOwner) {
+    player1Scoreboard.classList.toggle(
+      KNOWN_CSS_CLASSES.gameStatus.playerTurnActive
+    );
+    player2Scoreboard.classList.toggle(
+      KNOWN_CSS_CLASSES.gameStatus.playerTurnActive
+    );
+  } else {
+    player1Scoreboard.classList.toggle(
+      KNOWN_CSS_CLASSES.gameStatus.playerTurnActive
+    );
+    player2Scoreboard.classList.toggle(
+      KNOWN_CSS_CLASSES.gameStatus.playerTurnActive
+    );
+  }
+
+  const {
+    game: {
+      turns: { waiting, activeTurn },
+    },
+  } = FIXTURE_TEXT;
+
+  p1Status.innerText = isP1CurrentTurnOwner ? waiting : activeTurn;
+  p2Status.innerText = isP1CurrentTurnOwner ? activeTurn : waiting;
+
+  appState.game.turns.currentTurn = isP1CurrentTurnOwner
+    ? GAME_CONFIG.players.p2.id
+    : GAME_CONFIG.players.p1.id;
+};
   const template = document.getElementById(templateId).content.cloneNode(true);
   return document
     .importNode(template, true)

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -50,9 +50,13 @@ const GAME_CONFIG = {
   players: {
     p1: {
       checkerIdentifier: 1,
+      checkerClass: KNOWN_CSS_CLASSES.whiteChecker,
+      id: "p1",
     },
     p2: {
       checkerIdentifier: 2,
+      checkerClass: KNOWN_CSS_CLASSES.redChecker,
+      id: "p2",
     },
   },
 };

--- a/index.html
+++ b/index.html
@@ -41,27 +41,23 @@
         <button class="game-area__button">New game</button>
       </section>
       <section class="main-content__score-area">
-        <div class="score-area__player-1">
-          <h2 class="player-title">Player 1</h2>
-          <div class="player-1__turn">
-            <span class="player-title__status status--active">Active turn</span>
-          </div>
+        <div class="score-area__player player-1 status--active">
+          <h2 class="player__title">Player 1</h2>
+          <span class="player__status">Active turn</span>
           <div class="player-1__pieces">
             <h3>
               Pieces remaining:
-              <span class="player-1__pieces__remaining">12</span>
+              <span class="pieces__remaining pieces__remaining--p1">12</span>
             </h3>
           </div>
         </div>
-        <div class="score-area__player-2">
-          <h2 class="player-title">Player 2</h2>
-          <div class="player-2__turn">
-            <span class="player-title__status status--waiting">Waiting</span>
-          </div>
+        <div class="score-area__player player-2">
+          <h2 class="player__title">Player 2</h2>
+          <span class="player__status">Waiting</span>
           <div class="player-2__pieces">
             <h3>
               Pieces remaining:
-              <span class="player-2__pieces__remaining">12</span>
+              <span class="pieces__remaining pieces__remaining--p2">12</span>
             </h3>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -41,7 +41,30 @@
         <button class="game-area__button">New game</button>
       </section>
       <section class="main-content__score-area">
-        <!-- TODO: Add players, scores and remaining tiles -->
+        <div class="score-area__player-1">
+          <h2 class="player-title">Player 1</h2>
+          <div class="player-1__turn">
+            <span class="player-title__status status--active">Active turn</span>
+          </div>
+          <div class="player-1__pieces">
+            <h3>
+              Pieces remaining:
+              <span class="player-1__pieces__remaining">12</span>
+            </h3>
+          </div>
+        </div>
+        <div class="score-area__player-2">
+          <h2 class="player-title">Player 2</h2>
+          <div class="player-2__turn">
+            <span class="player-title__status status--waiting">Waiting</span>
+          </div>
+          <div class="player-2__pieces">
+            <h3>
+              Pieces remaining:
+              <span class="player-2__pieces__remaining">12</span>
+            </h3>
+          </div>
+        </div>
       </section>
     </main>
     <footer class="footer">

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 
     <template id="red-piece">
       <img
-        class="checker--red"
+        class="checker checker--red"
         src="/assets/img/red-piece.png"
         alt="red checker"
       />
@@ -102,7 +102,7 @@
 
     <template id="white-piece">
       <img
-        class="checker--white"
+        class="checker checker--white"
         src="/assets/img/white-piece.png"
         alt="white checker"
       />


### PR DESCRIPTION
# Fix

**Added scoreboard and turn switching**

# Description

This PR includes the implementation of the players scoreboards as well as turn switching. Currently the app only switches turn when a player clicks on a **checker** of their own. It also allows the user to start a brand new game, hiding the _start game_ button and showing a scoreboard which is (at the moment) very limited functionally speaking.

# Changes screenshots

## Desktop

![image](https://user-images.githubusercontent.com/39205380/122987006-82dc2800-d376-11eb-82b9-98d327395d71.png)
![image](https://user-images.githubusercontent.com/39205380/122987192-b28b3000-d376-11eb-9c84-79edda44b872.png)


## Mobile

![image](https://user-images.githubusercontent.com/39205380/122987143-a56e4100-d376-11eb-89b9-1184b20ce133.png)
![image](https://user-images.githubusercontent.com/39205380/122987161-aacb8b80-d376-11eb-9a85-f8641dc2a27d.png)

