### PR TITLE
Feature: Checker eating

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Trabajo practico 1 - ✨*Checkers*✨
 
-## Contenido de la tarea
+## Contenido de la actividad
 
-Continuar el proyecto desarrollado en el Trabajo Practico N1, agregandole las primeras reglas del juego de Damas. El objetivo de esta semana es poder seleccionar fichas por turno, es decir que se debe detectar el jugador actual, y solo se pueden seleccionar casilleros correspondientes al color de ficha de dicho jugador. No es necesario crear reglas de movimiento de fichas diagonales, solo turnos.
+Continuar el proyecto desarrollado en la Clase 11, agregandole jugabilidad a las Damas. El objetivo de esta semana es poder comer fichas del oponente, es decir que se debe detectar el jugador actual, la ficha seleccionada y los casilleros disponibles para mover dicha ficha o comer una ficha contigua. Cuanto el jugador termina su movimiento, se debe pasar el turno al siguiente jugador. No es necesario crear la habilidad de comer mas de una ficha a la vez, ni detectar si se ha ganado la partida.
 
 El codigo HTML, CSS y JavaScript desarrollado debe ser subido a Github con sus commits correspondientes.
 
-El repositorio debe ser el mismo que se utilizó para la Clase 09, actualizando el Readme y los cambios deben ser visibles utilizando Github Pages.
+El repositorio debe ser el mismo que se utilizó para la Clase 10, actualizando el Readme y los cambios deben ser visibles utilizando Github Pages.
 
 Esta semana se evaluará:
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,7 @@
   --pure-white: #fff;
   --red: #ff5f56;
   --blue: #0070f3;
+  --yellow: #e3b341;
 
   /* Borders */
   --border-color: var(--dark-gray);
@@ -22,6 +23,7 @@
   --button-background-color--primary: var(--green);
   --player-1-accent-color: var(--blue);
   --player-2-accent-color: var(--red);
+  --selected-tile-color: var(--yellow);
 
   /* Font */
   --font-color: var(--white);
@@ -236,6 +238,11 @@
 /* Start game button shown by default, hidden on game start */
 .game-area__button.game-started {
   display: none;
+}
+
+/* Had to forcedly over-specify selectors to override black tile color */
+div.game-area__board div.board__row div.row__tile.selected-tile {
+  background-color: var(--selected-tile-color);
 }
 
 /* Desktop */

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -118,15 +118,15 @@ const renderNewTurn = () => {
 
   const [player1Scoreboard, player2Scoreboard] =
     scoreboard.getElementsByClassName(
-      KNOWN_CSS_CLASSES.playersScoreboards.both
+      KNOWN_CSS_CLASSES.playersScoreboards.both.scoreboard
     );
 
   const [p1Status] = player1Scoreboard.getElementsByClassName(
-    KNOWN_CSS_CLASSES.playersScoreboards.status
+    KNOWN_CSS_CLASSES.playersScoreboards.both.status
   );
 
   const [p2Status] = player2Scoreboard.getElementsByClassName(
-    KNOWN_CSS_CLASSES.playersScoreboards.status
+    KNOWN_CSS_CLASSES.playersScoreboards.both.status
   );
 
   if (isP1CurrentTurnOwner) {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -363,6 +363,9 @@ const onClickTileHandler = ({
 };
 
 const renderRows = (boardElement, initialBoardMatrix) => {
+  while (boardElement.firstChild) {
+    boardElement.removeChild(boardElement.lastChild);
+  }
   const rowElementParams = {
     templateId: KNOWN_HTML_TEMPLATE_IDS.board.row,
     elementCssClass: KNOWN_CSS_CLASSES.row,

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -215,14 +215,7 @@ const onClickTileHandler = ({
     tile.classList.add(KNOWN_CSS_CLASSES.gameStatus.selectedTile);
     const availableMovements = getAvailableMovements(rowIndex, cellIndex);
 
-    for (const item of availableMovements) {
-      for (const emptyTile of item) {
-        const [row, col] = emptyTile;
-        const tileID = generateTileId(row, col);
-        const tile = document.getElementById(tileID);
-        tile.classList.add(KNOWN_CSS_CLASSES.gameStatus.selectedTile);
-      }
-    }
+    renderAvailableMovements(clickedTileRowIndex, clickedTileColumnIndex);
     appState.game.checkersStatus.isSelectingMovement = true;
   }
 
@@ -403,5 +396,18 @@ const startGame = () => {
   hideButtonShowScores();
   appState.game.turns.currentTurn = GAME_CONFIG.players.p1.id;
 };
+
+function renderAvailableMovements(rowIndex, cellIndex) {
+  const availableMovements = getAvailableMovements(rowIndex, cellIndex);
+
+  for (const item of availableMovements) {
+    for (const emptyTile of item) {
+      const [row, col] = emptyTile;
+      const tileID = generateTileId(row, col);
+      const tile = document.getElementById(tileID);
+      tile?.classList.add(KNOWN_CSS_CLASSES.gameStatus.selectedTile);
+    }
+  }
+}
 
 window.onload = bootstrapApp(GAME_CONFIG);

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -9,11 +9,18 @@ const KNOWN_CSS_CLASSES = {
   checker: "checker",
   startGameButton: "game-area__button",
   scoreboard: "main-content__score-area",
+
   playersScoreboards: {
-    both: "score-area__player",
+    both: {
+      scoreboard: "score-area__player",
     status: "player__status",
-    p1: "score-area__player player1",
-    p2: "score-area__player player2",
+    },
+    p1: {
+      piecesRemaining: "pieces__remaining--p1",
+    },
+    p2: {
+      piecesRemaining: "pieces__remaining--p2",
+    },
   },
   gameStatus: {
     gameStarted: "game-started",

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -104,6 +104,10 @@ const appState = {
   },
 };
 
+// TODO: Find where to fit these variables into appState.
+let availableMovements = null;
+let clickedChecker = null;
+
 const renderNewTurn = () => {
   const isP1CurrentTurnOwner =
     appState.game.turns.currentTurn === GAME_CONFIG.players.p1.id;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,7 +13,7 @@ const KNOWN_CSS_CLASSES = {
   playersScoreboards: {
     both: {
       scoreboard: "score-area__player",
-    status: "player__status",
+      status: "player__status",
     },
     p1: {
       piecesRemaining: "pieces__remaining--p1",
@@ -272,7 +272,6 @@ const onClickTileHandler = ({
     cellIndex: clickedTileColumnIndex,
   },
 }) => {
-  // console.log(appState.game.checkersStatus);
   const hasOwnChecker =
     appState.game.turns.currentTurn != null &&
     !!tile.querySelector(
@@ -358,7 +357,6 @@ const onClickTileHandler = ({
         }
       }
     }
-    renderNewTurn();
   }
 };
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -170,13 +170,87 @@ const generateTileId = (rowIndex, cellIndex) =>
   `row-${rowIndex}-tile-${cellIndex}`;
 
 const getAvailableMovements = (row, column) => {
-  const reducerFunction = (accumulator, currentRow, currentRowIndex) => {
+  const reducerFunction = (
+    accumulator,
+    currentRow,
+    currentRowIndex,
+    sourceArray
+  ) => {
     accumulator.push(
-      currentRow.map((cell, cellIndex) => {
-        if (currentRowIndex === row + 1 || currentRowIndex === row - 1) {
-          if (cellIndex === column + 1 || cellIndex === column - 1) {
-            if (cell !== 1 && cell !== 2) {
-              return [currentRowIndex, cellIndex];
+      currentRow.map((cell, currentCellIndex) => {
+        const currentPlayer = appState.game.turns.currentTurn;
+        if (
+          GAME_CONFIG.players[currentPlayer].movementDirection ===
+          KNOWN_MOVEMENT_DIRECTIONS.topDown
+        ) {
+          //TODO: FIX THIS FOR GOD'S SAKE 😰 (nice code, dude)
+          if (currentRowIndex === row + 1) {
+            if (
+              currentCellIndex === column + 1 ||
+              currentCellIndex === column - 1
+            ) {
+              if (
+                cell !== GAME_CONFIG.players.p1.checkerIdentifier &&
+                cell !== GAME_CONFIG.players.p2.checkerIdentifier
+              ) {
+                return [currentRowIndex, currentCellIndex];
+              } else {
+                if (cell === GAME_CONFIG.players.p2.checkerIdentifier) {
+                  if (
+                    sourceArray[currentRowIndex + 1] &&
+                    sourceArray[currentRowIndex + 1][
+                      currentCellIndex < column ? column - 2 : column + 2
+                    ] == null
+                  ) {
+                    return [
+                      currentRowIndex + 1,
+                      currentCellIndex < column ? column - 2 : column + 2,
+                      {
+                        eatenCell: {
+                          row: currentRowIndex,
+                          column: currentCellIndex,
+                          owner: cell,
+                        },
+                      },
+                    ];
+                  }
+                }
+              }
+            }
+          }
+        } else {
+          if (currentRowIndex === row - 1) {
+            if (
+              currentCellIndex === column + 1 ||
+              currentCellIndex === column - 1
+            ) {
+              if (
+                cell !== GAME_CONFIG.players.p1.checkerIdentifier &&
+                cell !== GAME_CONFIG.players.p2.checkerIdentifier
+              ) {
+                return [currentRowIndex, currentCellIndex];
+              } else {
+                if (cell === GAME_CONFIG.players.p1.checkerIdentifier) {
+                  if (
+                    sourceArray[currentRowIndex - 1] &&
+                    sourceArray[currentRowIndex - 1][
+                      currentCellIndex < column ? column - 2 : column + 2
+                    ] === null
+                  ) {
+                    return [
+                      currentRowIndex - 1,
+                      currentCellIndex < column ? column - 2 : column + 2,
+                      {
+                        eatenCell: {
+                          row: currentRowIndex,
+                          column: currentCellIndex,
+                          owner: cell,
+                        },
+                      },
+                    ];
+                  }
+                }
+              }
             }
           }
         }

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -267,7 +267,10 @@ const getAvailableMovements = (row, column) => {
 
 const onClickTileHandler = ({
   element: tile,
-  position: { rowIndex, cellIndex },
+  position: {
+    rowIndex: clickedTileRowIndex,
+    cellIndex: clickedTileColumnIndex,
+  },
 }) => {
   // console.log(appState.game.checkersStatus);
   const hasOwnChecker =

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const KNOWN_CSS_CLASSES = {
   board: "game-area__board",
   row: "board__row",

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -53,6 +53,11 @@ const KNOWN_HTML_TEMPLATE_IDS = {
   },
 };
 
+const KNOWN_MOVEMENT_DIRECTIONS = {
+  topDown: "topDown",
+  bottomUp: "bottomUp",
+};
+
 const KNOWN_TYPES = {
   undefined: "undefined",
 };
@@ -67,11 +72,13 @@ const GAME_CONFIG = {
       checkerIdentifier: 1,
       checkerClass: KNOWN_CSS_CLASSES.whiteChecker,
       id: "p1",
+      movementDirection: KNOWN_MOVEMENT_DIRECTIONS.topDown,
     },
     p2: {
       checkerIdentifier: 2,
       checkerClass: KNOWN_CSS_CLASSES.redChecker,
       id: "p2",
+      movementDirection: KNOWN_MOVEMENT_DIRECTIONS.bottomUp,
     },
   },
 };


### PR DESCRIPTION
# Fix

**Checker eating**

# Description

This PR includes:
- The ability for the players to eat each other's checkers on turns.
- The dynamic update of the scoreboard showing how many checkers the players have left in the board.

# Changes screenshots

## Desktop

### Checker highlighting
![image](https://user-images.githubusercontent.com/39205380/125153558-e1e9bd00-e12a-11eb-8c40-3f23be9875a5.png)

### Basic movement and turns swapping
![image](https://user-images.githubusercontent.com/39205380/125153562-f0d06f80-e12a-11eb-9116-720fd26f2106.png)

### Board state before eating
![image](https://user-images.githubusercontent.com/39205380/125153622-81a74b00-e12b-11eb-8b23-f8118d4179e4.png)

### Board state after eating, turn swapping and scoreboard update
![image](https://user-images.githubusercontent.com/39205380/125153596-4573ea80-e12b-11eb-8dc1-7bdbc82e70fa.png)

## Mobile

There were no significant changes.
